### PR TITLE
BUG FIX: percentage and remaining are being overloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
   seats:
     runs-on: ubuntu-latest
     steps:
-      - uses: austenstone/seat-count-action@v3
+      - uses: austenstone/seat-count-action@v3.0
         id: seats
         with:
           github-token: ${{secrets.TOKEN}}

--- a/src/run.ts
+++ b/src/run.ts
@@ -49,9 +49,9 @@ const run = async (): Promise<void> => {
         core.setOutput('remaining', 'unlimited');
         percentage = 0;
       } else {
-        const percentage = Math.round(((plan.filled_seats / plan.seats) * 100));
+        percentage = Math.round(((plan.filled_seats / plan.seats) * 100));
         core.info(`${percentage}% of seats used`)
-        const remaining = plan.seats - plan.filled_seats;
+        remaining = plan.seats - plan.filled_seats;
         core.info(`${remaining} seats remaining`)
       }
       core.setOutput('percentage', percentage);


### PR DESCRIPTION
Setting remaining and percentage as const is overloading them and scopes these vars only to the else block. If the intention is to set them to zero for other types of accounts and otherwise set them to found values you should not use const on lines 52 and 54 @austenstone for review

Current code ensures remaining and percentage will always output as 0.

<!-- 
Thanks for creating this pull request 🤗

Keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

