### PR TITLE
Fix logging and output of variables

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -46,14 +46,14 @@ const run = async (): Promise<void> => {
     if (plan.filled_seats && plan.seats) {
       let percentage = 0, remaining = 0;
       if (plan.seats === 'unlimited') {
-        core.setOutput('remaining', 'unlimited');
+        remaining = 'unlimited';
         percentage = 0;
       } else {
-        const percentage = Math.round(((plan.filled_seats / plan.seats) * 100));
-        core.info(`${percentage}% of seats used`)
-        const remaining = plan.seats - plan.filled_seats;
-        core.info(`${remaining} seats remaining`)
+        percentage = Math.round(((plan.filled_seats / plan.seats) * 100));
+        remaining = plan.seats - plan.filled_seats;
       }
+      core.info(`${remaining} seats remaining`);
+      core.info(`${percentage}% of seats used`);
       core.setOutput('percentage', percentage);
       core.setOutput('remaining', remaining);
     }


### PR DESCRIPTION
- unlimited plan:
  - currently does not `core.info` log the outputs
  - sets the `remaining` output to `unlimited` but does not update the corresponding variable - this causes the output to later on be overridden with 0
- limited plan:
  - instead of assigning to the `remaining` and `percentage` variables from the parent scope, redefines them as consts in the current scope - `core.setOutput` in the parent scope thus always sets outputs to 0, 0.


